### PR TITLE
Pay CPU Contract

### DIFF
--- a/documentation/example/.env.example
+++ b/documentation/example/.env.example
@@ -1,0 +1,4 @@
+# rename this to .env, fill in the values
+
+PAYCPU_KEY="PAY CPU KEY HERE"
+PRIVATE_KEY="PRIVATE KEY HERE"

--- a/documentation/example/example_call_paycpu.js
+++ b/documentation/example/example_call_paycpu.js
@@ -1,11 +1,22 @@
-const { Api, JsonRpc, JsSignatureProvider } = require('eosjs');
+require('dotenv').config(); 
+const { Api, JsonRpc } = require('eosjs');
 const { TextEncoder, TextDecoder } = require('util');
+const { JsSignatureProvider } = require('eosjs/dist/eosjs-jssig')
+const fetch = require('isomorphic-fetch'); // Import the 'isomorphic-fetch' package
+
 
 // Configure EOSJS with the endpoint URL and the private key of the account
 const endpoint = 'https://mainnet.telos.net';  // Replace with your EOSIO endpoint URL
-const privateKey = 'YOUR_PRIVATE_KEY';  // Replace with the private key of the account
 
-const signatureProvider = new JsSignatureProvider([privateKey]);
+const contractPrivateKey = process.env.PAYCPU_KEY;
+const targetPrivateKey = process.env.PRIVATE_KEY;
+
+console.log("keys " + [contractPrivateKey, targetPrivateKey])
+
+const signatureProvider = new JsSignatureProvider([
+  contractPrivateKey,
+  targetPrivateKey,
+]);
 const rpc = new JsonRpc(endpoint, { fetch });
 const api = new Api({
   rpc,
@@ -15,8 +26,8 @@ const api = new Api({
 });
 
 // Define the contract account and the target account
-const contractAccount = 'paycpu';  // Replace with the account name of the paycpu contract
-const targetAccount = 'alice';  // Replace with the target account you want to pass to the payforcpu action
+const contractAccount = 'paycpu.hypha';  // Replace with the account name of the paycpu contract
+const targetAccount = 'testingseeds';  // Replace with the target account you want to pass to the payforcpu action
 
 async function callPayForCpu() {
   try {
@@ -28,7 +39,7 @@ async function callPayForCpu() {
       account: contractAccount,
       name: 'payforcpu',
       authorization: [
-        { actor: contractAccount, permission: 'active' },  // Authorize the contract
+        { actor: contractAccount, permission: 'payforcpu' },  // Authorize the contract
         { actor: targetAccount, permission: 'active' },    // Authorize the target account
       ],
       data: {
@@ -56,17 +67,17 @@ async function callPayForCpu() {
 // Call the payforcpu function
 callPayForCpu();
 
-// ❯ cleos push action paycpu.hypha configure '{ "contractName":"dao.hypha" }' -p paycpu.hypha@active
+// ❯ cleosm push action paycpu.hypha configure '{ "contractName":"dao.hypha" }' -p paycpu.hypha@active
 // executed transaction: 71b9917b2ed9a24a3f15c35ad77effc3c5c86bba45563ae27f8ad02d86b2681c  104 bytes  3991 us
 // #  paycpu.hypha <= paycpu.hypha::configure      {"contractName":"dao.hypha"}
 
-❯ cleos get table paycpu.hypha paycpu.hypha configs
-{
-    "rows": [{
-        "contractName": "dao.hypha"
-      }
-    ],
-    "more": false,
-    "next_key": "",
-    "next_key_bytes": ""
-  }
+// ❯ cleos get table paycpu.hypha paycpu.hypha configs
+// {
+//     "rows": [{
+//         "contractName": "dao.hypha"
+//       }
+//     ],
+//     "more": false,
+//     "next_key": "",
+//     "next_key_bytes": ""
+//   }

--- a/documentation/example/example_call_paycpu.js
+++ b/documentation/example/example_call_paycpu.js
@@ -67,11 +67,13 @@ async function callPayForCpu() {
 // Call the payforcpu function
 callPayForCpu();
 
-// ❯ cleosm push action paycpu.hypha configure '{ "contractName":"dao.hypha" }' -p paycpu.hypha@active
-// executed transaction: 71b9917b2ed9a24a3f15c35ad77effc3c5c86bba45563ae27f8ad02d86b2681c  104 bytes  3991 us
-// #  paycpu.hypha <= paycpu.hypha::configure      {"contractName":"dao.hypha"}
+// telos mainnet setup
+// cleosm push action paycpu.hypha configure '{ "contractName":"dao.hypha" }' -p paycpu.hypha@active
 
-// ❯ cleos get table paycpu.hypha paycpu.hypha configs
+// telos testnet setup
+// cleost push action paycpuxhypha configure '{ "contractName":"mtdhoxhyphaa" }' -p paycpuxhypha@active
+
+// ❯ cleosm get table paycpu.hypha paycpu.hypha configs
 // {
 //     "rows": [{
 //         "contractName": "dao.hypha"

--- a/documentation/example/package.json
+++ b/documentation/example/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "eosjs-example",
+    "version": "1.0.0",
+    "description": "Example code for calling payforcpu action using EOSJS",
+    "main": "index.js",
+    "scripts": {
+        "start": "node example_call_paycpu.js"
+    },
+    "author": "Nikolaus Heger",
+    "license": "MIT",
+    "dependencies": {
+        "dotenv": "^16.0.3",
+        "eosjs": "^22.1.0",
+        "isomorphic-fetch": "^3.0.0",
+        "node-fetch": "^3.3.1"
+    }
+}

--- a/documentation/example_call_paycpu.js
+++ b/documentation/example_call_paycpu.js
@@ -1,0 +1,72 @@
+const { Api, JsonRpc, JsSignatureProvider } = require('eosjs');
+const { TextEncoder, TextDecoder } = require('util');
+
+// Configure EOSJS with the endpoint URL and the private key of the account
+const endpoint = 'https://mainnet.telos.net';  // Replace with your EOSIO endpoint URL
+const privateKey = 'YOUR_PRIVATE_KEY';  // Replace with the private key of the account
+
+const signatureProvider = new JsSignatureProvider([privateKey]);
+const rpc = new JsonRpc(endpoint, { fetch });
+const api = new Api({
+  rpc,
+  signatureProvider,
+  textDecoder: new TextDecoder(),
+  textEncoder: new TextEncoder(),
+});
+
+// Define the contract account and the target account
+const contractAccount = 'paycpu';  // Replace with the account name of the paycpu contract
+const targetAccount = 'alice';  // Replace with the target account you want to pass to the payforcpu action
+
+async function callPayForCpu() {
+  try {
+    // Get the account information to fetch the required authorization keys
+    const account = await rpc.get_account(targetAccount);
+
+    // Construct the transaction actions
+    const actions = [{
+      account: contractAccount,
+      name: 'payforcpu',
+      authorization: [
+        { actor: contractAccount, permission: 'active' },  // Authorize the contract
+        { actor: targetAccount, permission: 'active' },    // Authorize the target account
+      ],
+      data: {
+        account: targetAccount,
+      },
+    }];
+
+    // Construct the transaction
+    const transaction = {
+      actions,
+    };
+
+    // Sign and broadcast the transaction
+    const result = await api.transact(transaction, {
+      blocksBehind: 3,
+      expireSeconds: 30,
+    });
+
+    console.log('Transaction ID:', result.transaction_id);
+  } catch (error) {
+    console.error('Error:', error);
+  }
+}
+
+// Call the payforcpu function
+callPayForCpu();
+
+// ❯ cleos push action paycpu.hypha configure '{ "contractName":"dao.hypha" }' -p paycpu.hypha@active
+// executed transaction: 71b9917b2ed9a24a3f15c35ad77effc3c5c86bba45563ae27f8ad02d86b2681c  104 bytes  3991 us
+// #  paycpu.hypha <= paycpu.hypha::configure      {"contractName":"dao.hypha"}
+
+❯ cleos get table paycpu.hypha paycpu.hypha configs
+{
+    "rows": [{
+        "contractName": "dao.hypha"
+      }
+    ],
+    "more": false,
+    "next_key": "",
+    "next_key_bytes": ""
+  }

--- a/include/paycpu.hpp
+++ b/include/paycpu.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <eosio/eosio.hpp>
+#include <eosio/asset.hpp>
+
+using namespace eosio;
+
+CONTRACT paycpu : public contract {
+public:
+    using contract::contract;
+
+    ACTION payforcpu(name account);
+
+private:
+
+    TABLE nametoid {
+        uint64_t id;
+        name name;
+
+        uint64_t primary_key() const { return name.value; }
+        uint64_t by_id() const { return id; }
+    };
+
+    typedef multi_index<"members"_n, nametoid,
+        indexed_by<"bydocid"_n, const_mem_fun<nametoid, uint64_t, &nametoid::by_id>>
+    > members_table;
+    
+};
+
+EOSIO_DISPATCH(paycpu, (payforcpu))

--- a/include/paycpu.hpp
+++ b/include/paycpu.hpp
@@ -15,6 +15,8 @@ public:
     ACTION configure(name contractName);
 
 private:
+
+    /// This table definition is from dao.hypha
     TABLE nametoid {
         uint64_t id;
         name name;
@@ -27,6 +29,7 @@ private:
         indexed_by<"bydocid"_n, const_mem_fun<nametoid, uint64_t, &nametoid::by_id>>
     > members_table;
 
+    /// config table to configure the dao contract
     TABLE config {
         name contractName;
 

--- a/include/paycpu.hpp
+++ b/include/paycpu.hpp
@@ -2,8 +2,8 @@
 
 #include <eosio/eosio.hpp>
 #include <eosio/asset.hpp>
+#include <eosio/multi_index.hpp>
 #include <eosio/singleton.hpp>
-
 
 using namespace eosio;
 
@@ -33,9 +33,8 @@ private:
         uint64_t primary_key() const { return 0; }
     };
 
+    typedef eosio::multi_index<"configs"_n, config> configs_table;
     typedef eosio::singleton<"configs"_n, config> configs_singleton;
-    typedef eosio::multi_index<"configs"_n, config> dump_for_configs;
-
 };
 
 EOSIO_DISPATCH(paycpu, (payforcpu)(configure))

--- a/include/paycpu.hpp
+++ b/include/paycpu.hpp
@@ -2,6 +2,8 @@
 
 #include <eosio/eosio.hpp>
 #include <eosio/asset.hpp>
+#include <eosio/singleton.hpp>
+
 
 using namespace eosio;
 
@@ -10,9 +12,9 @@ public:
     using contract::contract;
 
     ACTION payforcpu(name account);
+    ACTION configure(name contractName);
 
 private:
-
     TABLE nametoid {
         uint64_t id;
         name name;
@@ -24,7 +26,16 @@ private:
     typedef multi_index<"members"_n, nametoid,
         indexed_by<"bydocid"_n, const_mem_fun<nametoid, uint64_t, &nametoid::by_id>>
     > members_table;
-    
+
+    TABLE config {
+        name contractName;
+
+        uint64_t primary_key() const { return 0; }
+    };
+
+    typedef eosio::singleton<"configs"_n, config> configs_singleton;
+    typedef eosio::multi_index<"configs"_n, config> dump_for_configs;
+
 };
 
-EOSIO_DISPATCH(paycpu, (payforcpu))
+EOSIO_DISPATCH(paycpu, (payforcpu)(configure))

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -123,6 +123,7 @@ const accountsMetadata = (network) => {
       login: contract('logintohypha', 'login'),
       sale: contract('sale.hypha', 'sale'),
       joinhypha: contract('join.hypha', 'joinhypha'),
+      paycpu: contract('paycpu.hypha', 'paycpu'),
     }
   } else if (network == networks.telosMainnet) {
     return {
@@ -130,6 +131,7 @@ const accountsMetadata = (network) => {
 
       sale: contract('sale.hypha', 'sale'),
       joinhypha: contract('join.hypha', 'joinhypha'),
+      paycpu: contract('paycpu.hypha', 'paycpu'),
     }
   } else if (network == networks.telosTestnet) {
     return {
@@ -145,12 +147,14 @@ const accountsMetadata = (network) => {
       login: contract('logintohypha', 'login'),
       sale: contract('sale.hypha', 'sale'),
       joinhypha: contract('joinhypha111', 'joinhypha'),
+      paycpu: contract('paycpuxhypha', 'paycpu'),
     }
   } else if (network == networks.eosMainnet) {
     return {
       // EOS mainnet doesn't have most of the accounts
       joinhypha: contract('join.hypha', 'joinhypha'),
       login: contract('logintohypha', 'login'),
+      paycpu: contract('paycpu.hypha', 'paycpu'),
     }
   } else if (network == networks.eosTestnet) {
     return {
@@ -158,6 +162,7 @@ const accountsMetadata = (network) => {
       sale: contract('sale.hypha', 'sale'),
       login: contract('logintohypha', 'login'),
       joinhypha: contract('joinxhypha11', 'joinhypha'),
+      paycpu: contract('paycpu.hypha', 'paycpu'),
     }
   } else {
     throw new Error(`${network} deployment not supported`)
@@ -190,6 +195,17 @@ allBankAccountNames.sort()
 
 /// Set up all special permissions
 
+
+// This is a semi-public key that can be used to pay for CPU but will only work for hypha members 
+const payForCPUKeys = {
+  [networks.local]: 'EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV',
+  [networks.telosMainnet]: 'EOS65Ug7bqgMdom1Vu9QPdRu4ie7Yey4VmyoJDvcE4H9vfy8qC8yy',
+  [networks.telosTestnet]: 'EOS65Ug7bqgMdom1Vu9QPdRu4ie7Yey4VmyoJDvcE4H9vfy8qC8yy',
+  [networks.eosMainnet]: 'EOS65Ug7bqgMdom1Vu9QPdRu4ie7Yey4VmyoJDvcE4H9vfy8qC8yy',
+}
+
+const payForCPUPublicKey = payForCPUKeys[chainId]
+
 var permissions = [{
   target: `${accounts.sale.account}@active`,
   actor: `${accounts.sale.account}@eosio.code`
@@ -203,7 +219,16 @@ var permissions = [{
 }, {
   target: `${accounts.joinhypha.account}@active`,
   actor: `${accounts.joinhypha.account}@eosio.code`
-}]
+}, {
+  target: `${accounts.paycpu.account}@payforcpu`,
+  key: payForCPUPublicKey,
+  parent: 'active'
+}, {
+  target: `${accounts.paycpu.account}@payforcpu`,
+  action: 'payforcpu'
+}
+
+]
 
 const isTestnet = (chainId == networks.telosTestnet) || (chainId == networks.eosTestnet)
 const isLocalNet = chainId == networks.local

--- a/src/paycpu.cpp
+++ b/src/paycpu.cpp
@@ -4,9 +4,27 @@ void paycpu::payforcpu(name account) {
     require_auth(account);
     require_auth(_self);
 
-    // Check if the provided account exists in the members table of dao.hypha contract
-    members_table members("dao.hypha"_n, "dao.hypha"_n.value);
-    auto member = members.find(account.value);
-    eosio::check(member != members.end(), "Account not found in members table of dao.hypha contract");
+    // Retrieve the contract name from the configs table
+    configs_singleton configs(_self, _self.value);
+    auto c = configs.get_or_create(_self, config{});
 
+    // Get the contract name from the config table entry
+    name contractName = c.contractName;
+
+    // Check if the provided account exists in the members table of the specified contract
+    members_table members(contractName, contractName.value);
+    auto member = members.find(account.value);
+    eosio::check(member != members.end(), "Account not found in members table");
+
+}
+
+void paycpu::configure(name contractName) {
+    require_auth(_self);
+
+    configs_singleton configs(_self, _self.value);
+    auto c = configs.get_or_create(_self, config{});
+
+    c.contractName = contractName;
+
+    configs.set(c, _self);
 }

--- a/src/paycpu.cpp
+++ b/src/paycpu.cpp
@@ -1,0 +1,12 @@
+#include "../include/paycpu.hpp"
+
+void paycpu::payforcpu(name account) {
+    require_auth(account);
+    require_auth(_self);
+
+    // Check if the provided account exists in the members table of dao.hypha contract
+    members_table members("dao.hypha"_n, "dao.hypha"_n.value);
+    auto member = members.find(account.value);
+    eosio::check(member != members.end(), "Account not found in members table of dao.hypha contract");
+
+}

--- a/src/paycpu.cpp
+++ b/src/paycpu.cpp
@@ -1,30 +1,26 @@
 #include "../include/paycpu.hpp"
 
-void paycpu::payforcpu(name account) {
+ACTION paycpu::payforcpu(name account) {
     require_auth(account);
     require_auth(_self);
 
-    // Retrieve the contract name from the configs table
     configs_singleton configs(_self, _self.value);
-    auto c = configs.get_or_create(_self, config{});
+    auto conf = configs.get();
+    name contractName = conf.contractName;
 
-    // Get the contract name from the config table entry
-    name contractName = c.contractName;
-
-    // Check if the provided account exists in the members table of the specified contract
     members_table members(contractName, contractName.value);
     auto member = members.find(account.value);
-    eosio::check(member != members.end(), "Account not found in members table");
+    check(member != members.end(), "Not a Hypha account");
 
 }
 
-void paycpu::configure(name contractName) {
+ACTION paycpu::configure(name contractName) {
     require_auth(_self);
 
     configs_singleton configs(_self, _self.value);
-    auto c = configs.get_or_create(_self, config{});
+    auto configEntry = configs.get_or_create(_self, config{});
 
-    c.contractName = contractName;
+    configEntry.contractName = contractName;
 
-    configs.set(c, _self);
+    configs.set(configEntry, _self);
 }


### PR DESCRIPTION
## Why is this needed?

This contract can pay for user's CPU

Just load it with coins / or rent via PowerUp

Any Hypha member can preload the payforcpu action, calling with the contract permission first. 

First signer pays -> Done.

## Comments

- [x] i have tested all changes

I ran the function on mainnet with 
- wrong paycpu key - fails
- wrong account key - fails
- correct paycpu key and hypha member account - works
- correct paycpu key and non-member - fails

These are all as expected. 